### PR TITLE
Fixes segfault issue

### DIFF
--- a/rdchiral/main.py
+++ b/rdchiral/main.py
@@ -292,6 +292,7 @@ def rdchiralRun(rxn, reactants, keep_isotopes=False, combine_enantiomers=True, r
                 new_b.SetBondDir(b.GetBondDir())
                 new_b.SetIsAromatic(b.GetIsAromatic())
             outcome = outcome.GetMol()
+            atoms_p = {a.GetIsotope(): a for a in outcome.GetAtoms() if a.GetIsotope()}
         else:
             if PLEVEL >= 3: print('No missing bonds')
         ###############################################################################


### PR DESCRIPTION
When reactants were missing bonds and molecules were re-stitched via a RWMol, using ```atoms_p```  to calculate ```atoms_diff``` would refer to atom objects that no longer exist