### PR TITLE
fix product atoms in are_unmapped_product_atoms loop

### DIFF
--- a/templates/template_extractor.py
+++ b/templates/template_extractor.py
@@ -729,6 +729,7 @@ def extract_from_reaction(reaction):
 
     if are_unmapped_product_atoms: # add fragment to template
         for product in products:
+            prod_atoms = product.GetAtoms()
             # Get unmapped atoms
             unmapped_ids = [
                 a.GetIdx() for a in prod_atoms if not a.HasProp('molAtomMapNumber')


### PR DESCRIPTION
line 738 uses prod_atoms from the previous loop. Added getAtoms() to are_unmapped_product_atoms loop.