### PR TITLE
Fixed bug with tetrahedral chirality

### DIFF
--- a/templates/template_extractor.py
+++ b/templates/template_extractor.py
@@ -51,7 +51,6 @@ def get_tagged_atoms_from_mol(mol):
 def atoms_are_different(atom1, atom2):
     '''Compares two RDKit atoms based on basic properties'''
 
-    if atom1.GetSmarts() != atom2.GetSmarts(): return True # easiest check
     if atom1.GetAtomicNum() != atom2.GetAtomicNum(): return True # must be true for atom mapping
     if atom1.GetTotalNumHs() != atom2.GetTotalNumHs(): return True
     if atom1.GetFormalCharge() != atom2.GetFormalCharge(): return True


### PR DESCRIPTION
- It's not appropriate to check whether SMARTS matches when comparing two atoms, since this contains tetrahedral chirality changes (@ versus @@)